### PR TITLE
add variadic sum and average; add floatPrecise helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,8 @@ module.exports = Object.assign(
   require('./lib/isEven.js'),
   require('./lib/isOdd.js'),
   require('./lib/isPositiveNumber.js'),
-  require('./lib/isNegativeNumber.js')
+  require('./lib/isNegativeNumber.js'),
+  require('./lib/sum.js'),
+  require('./lib/average.js'),
+  require('./lib/floatPrecise.js')
 );

--- a/lib/average.js
+++ b/lib/average.js
@@ -1,0 +1,25 @@
+const { sum } = require('./sum');
+const { floatPrecise } = require('./floatPrecise');
+
+exports.average = (...params) => {
+  handleErrors(params);
+
+  const result = sum(...params) / params.length;
+
+  // I couldn't actually find any examples of float imprecision
+  // when dividing a float by a whole number
+  // so this might not be neccessary. I just put it in for safety's sake - jmbothe
+  return floatPrecise(result);
+};
+
+const handleErrors = (params) => {
+  if (params.length === 0) throw new Error('Must provide one or more paramters');
+  if (params.some(param => typeof param !== 'number')) {
+    throw new Error('One of your parameters does not evaluate to a number');
+  }
+  // JS can only safely represent and compare integers between
+  // Number.MAX_SAFE_INTEGER and Number.MAX_SAFE_INTEGER
+  if (params.some(param => param > Number.MAX_SAFE_INTEGER || param < Number.MIN_SAFE_INTEGER)) {
+    throw new Error('Cannot reliably test primality of numbers larger than 9,007,199,254,740,991 or smaller than -9,007,199,254,740,991');
+  }
+};

--- a/lib/floatPrecise.js
+++ b/lib/floatPrecise.js
@@ -1,0 +1,18 @@
+exports.floatPrecise = (num) => {
+  const str = num.toString();
+
+  // if decimal terminates, or is not decimal, or is in exponential form, return num
+  if (str.length < 17 || !/\./.test(str) || /e/.test(str)) return num;
+
+  // Reverse loop through number looking for index of last precise digit.
+  // Imprecise floats typically contain a long string of 9s or 0s,
+  // somtimes terminating in some other number,
+  // so begin loop at second to last index.
+  let i = str.length - 2;
+  const imprecise = str[i] === '9' ? '9' : '0';
+
+  while (str[i] === imprecise) i -= 1;
+
+  // round number to index of last precise digit
+  return parseFloat(num.toPrecision(i));
+};

--- a/lib/sum.js
+++ b/lib/sum.js
@@ -1,0 +1,21 @@
+const { floatPrecise } = require('./floatPrecise');
+
+exports.sum = (...params) => {
+  handleErrors(params);
+
+  const result = params.reduce((prev, cur) => prev + cur, 0);
+
+  return floatPrecise(result);
+};
+
+const handleErrors = (params) => {
+  if (params.length === 0) throw new Error('Must provide one or more paramters');
+  if (params.some(param => typeof param !== 'number')) {
+    throw new Error('One of your parameters does not evaluate to a number');
+  }
+  // JS can only safely represent and compare integers
+  // between Number.MAX_SAFE_INTEGER and Number.MAX_SAFE_INTEGER
+  if (params.some(param => param > Number.MAX_SAFE_INTEGER || param < Number.MIN_SAFE_INTEGER)) {
+    throw new Error('Cannot reliably test primality of numbers larger than 9,007,199,254,740,991 or smaller than -9,007,199,254,740,991');
+  }
+};

--- a/spec/averageSpec.js
+++ b/spec/averageSpec.js
@@ -1,0 +1,27 @@
+const { average } = require('../lib/average');
+
+describe('average', () => {
+  it('should return the average of all parameters, given that all parameters evaluate to numbers', () => {
+    let result = average(1.2, 2, 9 / 3, +'4');
+    expect(result).toBe(2.55);
+
+    result = average(1);
+    expect(result).toBe(1);
+  });
+
+  it('should throw an error when no parameters are provided', () => {
+    expect(average).toThrow();
+  });
+
+  it('should throw an error when at least one parameter does not evaluate to a number', () => {
+    expect(() => average('yo')).toThrow();
+  });
+
+  it('should throw an error when at least one parameter evaluates to a number larger than Number.MAX_SAFE_INTEGER', () => {
+    expect(() => average(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+
+  it('should throw an error when at least one parameter evaluates to a number smaller than Number.MIN_SAFE_INTEGER', () => {
+    expect(() => average(Number.MIN_SAFE_INTEGER - 1)).toThrow();
+  });
+});

--- a/spec/floatPreciseSpec.js
+++ b/spec/floatPreciseSpec.js
@@ -1,0 +1,20 @@
+const { floatPrecise } = require('../lib/floatPrecise');
+
+describe('floatPrecise', () => {
+  it('should correct imprecision in JS floating point arithmetic', () => {
+    let result = floatPrecise(0.1 + 0.2);
+    expect(result).toBe(0.3);
+
+    result = floatPrecise(0.1 + 0.7);
+    expect(result).toBe(0.8);
+
+    result = floatPrecise(0.7 / 0.1);
+    expect(result).toBe(7);
+
+    result = floatPrecise(0.7 / 0.002);
+    expect(result).toBe(350);
+
+    result = floatPrecise(0.1 * 0.2);
+    expect(result).toBe(0.02);
+  });
+});

--- a/spec/sumSpec.js
+++ b/spec/sumSpec.js
@@ -1,0 +1,27 @@
+const { sum } = require('../lib/sum');
+
+describe('sum', () => {
+  it('should return the sum of all parameters, given that all parameters evaluate to numbers', () => {
+    let result = sum(1.2, 2, 9 / 3, +'4');
+    expect(result).toBe(10.2);
+
+    result = sum(1);
+    expect(result).toBe(1);
+  });
+
+  it('should throw an error when no parameters are provided', () => {
+    expect(sum).toThrow();
+  });
+
+  it('should throw an error when at least one parameter does not evaluate to a number', () => {
+    expect(() => sum('yo')).toThrow();
+  });
+
+  it('should throw an error when at least one parameter evaluates to a number larger than Number.MAX_SAFE_INTEGER', () => {
+    expect(() => sum(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+
+  it('should throw an error when at least one parameter evaluates to a number smaller than Number.MIN_SAFE_INTEGER', () => {
+    expect(() => sum(Number.MIN_SAFE_INTEGER - 1)).toThrow();
+  });
+});


### PR DESCRIPTION
I started out just planning to make the variadic `average()` function, but then realized that would depend on a `sum()` function, so I created that too. And of course I needed some way to deal with [imprecision in calculations with floating point numbers](http://floating-point-gui.de/), so I whipped up a quick and dirty helper `floatPrecise()` for that as well.